### PR TITLE
Update `organizations` and `organizationedits` for 2024 charter

### DIFF
--- a/002_CREATE_ORG_TABLE.sql
+++ b/002_CREATE_ORG_TABLE.sql
@@ -17,6 +17,7 @@ END $$;
 -- ADMIN: bypasses all requirements
 
 -- create organizations table
+-- see `022_EDIT_ORG_COLUMNS.sql` for modifications to columns
 CREATE TABLE organizations (
   id SERIAL PRIMARY KEY,
   name TEXT UNIQUE NOT NULL,

--- a/009_CREATE_ORG_EDITS_TABLE.sql
+++ b/009_CREATE_ORG_EDITS_TABLE.sql
@@ -1,5 +1,6 @@
 /* NULL means no update, admin client can skip over fields with value of null */
 /* if organizationEdit for org exists, then any updated fields will update that organizationEdit, else a new one is created */
+-- see `022_EDIT_ORG_COLUMNS.sql` for modifications to columns
 CREATE TABLE organizationedits (
   id SERIAL PRIMARY KEY,
   organization_id INT UNIQUE NOT NULL,

--- a/022_EDIT_ORG_COLUMNS.sql
+++ b/022_EDIT_ORG_COLUMNS.sql
@@ -1,0 +1,13 @@
+ALTER TABLE organizations DROP IF EXISTS benefit;
+ALTER TABLE organizationedits DROP IF EXISTS benefit;
+
+ALTER TABLE organizations ADD IF NOT EXISTS goals text;
+ALTER TABLE organizationedits ADD IF NOT EXISTS goals text;
+
+ALTER TABLE organizations ADD IF NOT EXISTS meeting_description text;
+ALTER TABLE organizationedits ADD IF NOT EXISTS meeting_description text;
+
+ALTER TABLE organizations ADD IF NOT EXISTS fair boolean;
+ALTER TABLE organizationedits ADD IF NOT EXISTS fair boolean;
+ALTER TABLE organizations ALTER fair SET DEFAULT false;
+ALTER TABLE organizationedits ALTER fair SET DEFAULT false;


### PR DESCRIPTION
Removes the defunct "purpose" column, and adds three new columns, "goals" and "meeting_description" (text) for the new entries on the form, and "fair" (boolean) for indicating interest in registering for the Clubs/Pubs fair.

This PR is a formality, and on approval/merge, a director must manually execute the query.