### PR TITLE
Allow `LOCKED` organizations on catalog

### DIFF
--- a/013_DATABASE_FUNCS.sql
+++ b/013_DATABASE_FUNCS.sql
@@ -30,6 +30,7 @@ AS $$
   )
 $$;
 
+-- see 026_DISPLAY_LOCKED_ORGS.sql for latest version
 CREATE OR REPLACE FUNCTION get_random_organizations(seed FLOAT, query_offset INT, query_limit INT)
 RETURNS SETOF organizations
 security invoker

--- a/026_DISPLAY_LOCKED_ORGS.sql
+++ b/026_DISPLAY_LOCKED_ORGS.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION get_random_organizations(seed FLOAT, query_offset INT, query_limit INT)
+RETURNS SETOF organizations
+security invoker
+set search_path = public
+stable
+AS $$
+BEGIN
+    PERFORM setseed(seed);
+
+    RETURN QUERY
+    SELECT * 
+    FROM organizations
+    WHERE organizations.state = 'UNLOCKED' OR organizations.state = 'ADMIN' OR organizations.state = 'LOCKED'
+    ORDER BY random()
+    LIMIT query_limit
+    OFFSET query_offset;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Replaces `get_random_organizations` with a slightly modified version