### PR TITLE
Revise settings format, add `faculty_email` field

### DIFF
--- a/011_CREATE_SETTINGS_TABLE.sql
+++ b/011_CREATE_SETTINGS_TABLE.sql
@@ -1,4 +1,5 @@
 -- one row MUST be present in `settings` to ensure proper operation -- see `023_ADD_DEFAULT_SETTING.sql`
+-- see `028_CHARTER_REVISIONS.sql` for modifications
 CREATE TABLE settings(
     Lock char(1) not null DEFAULT 'X', -- make this column contain only 1 value, but also be unique to create only 1 row
     /* Other columns */

--- a/028_CHARTER_REVISIONS.sql
+++ b/028_CHARTER_REVISIONS.sql
@@ -4,7 +4,7 @@ ALTER TABLE settings ADD COLUMN name VARCHAR PRIMARY KEY DEFAULT 'required_membe
 ALTER TABLE settings RENAME COLUMN required_members TO setting_value;
 ALTER TABLE settings ALTER COLUMN setting_value TYPE bigint; -- for timestamps
 -- add default
-INSERT INTO settings (name, setting_value) VALUES ('charter_deadline', 4294967296000);  -- arbitrary date in far future (2106)
+INSERT INTO settings (name, setting_value) VALUES ('charter_deadline', 0);  -- no deadline
 
 ALTER TABLE organizations ADD IF NOT EXISTS faculty_email VARCHAR;
 ALTER TABLE organizationedits ADD IF NOT EXISTS faculty_email VARCHAR;

--- a/028_CHARTER_REVISIONS.sql
+++ b/028_CHARTER_REVISIONS.sql
@@ -1,0 +1,9 @@
+ALTER TABLE settings DROP CONSTRAINT CK_T1_Locked RESTRICT;
+ALTER TABLE settings DROP COLUMN Lock;
+ALTER TABLE settings ADD COLUMN name VARCHAR PRIMARY KEY DEFAULT 'required_members';  -- maintains compatibility with 023
+ALTER TABLE settings RENAME COLUMN required_members TO setting_value;
+ALTER TABLE settings ALTER COLUMN setting_value TYPE bigint; -- for timestamps
+-- add default
+INSERT INTO settings (name, setting_value) VALUES ('charter_deadline', 4294967296000);  -- arbitrary date in far future (2106)
+
+ALTER TABLE organizations ADD COLUMN faculty_email VARCHAR;

--- a/028_CHARTER_REVISIONS.sql
+++ b/028_CHARTER_REVISIONS.sql
@@ -6,4 +6,5 @@ ALTER TABLE settings ALTER COLUMN setting_value TYPE bigint; -- for timestamps
 -- add default
 INSERT INTO settings (name, setting_value) VALUES ('charter_deadline', 4294967296000);  -- arbitrary date in far future (2106)
 
-ALTER TABLE organizations ADD COLUMN faculty_email VARCHAR;
+ALTER TABLE organizations ADD IF NOT EXISTS faculty_email VARCHAR;
+ALTER TABLE organizationedits ADD IF NOT EXISTS faculty_email VARCHAR;


### PR DESCRIPTION
Revises settings table to allow for a variety of 64-bit integer rows and values, not just the required_members setting.

Adds the faculty_email field to organization charters.

See https://github.com/stuysu/epsilon/issues/256